### PR TITLE
feat: add Xiaomi Mimo provider configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,15 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
 DEEPSEEK_API_KEY=
+DEEPSEEK_MODEL=deepseek-v4-pro
+DEEPSEEK_BASE_URL=https://api.deepseek.com
 QWEN_API_KEY=
 DASHSCOPE_API_KEY=
+QWEN_MODEL=qwen3.6-plus
+QWEN_BASE_URL=https://coding.dashscope.aliyuncs.com/v1
+MIMO_API_KEY=
+MIMO_MODEL=mimo-v2.5-pro
+MIMO_BASE_URL=https://token-plan-cn.xiaomimimo.com/v1
 
 # Auth Secret
 JWT_SECRET=your_jwt_secret_here

--- a/server.ts
+++ b/server.ts
@@ -98,6 +98,19 @@ let anthropic: Anthropic | null = null;
 let gemini: GoogleGenerativeAI | null = null;
 let deepseek: OpenAI | null = null;
 let qwen: OpenAI | null = null;
+let mimo: OpenAI | null = null;
+
+const DEEPSEEK_BASE_URL = process.env.DEEPSEEK_BASE_URL || "https://api.deepseek.com";
+const QWEN_BASE_URL = process.env.QWEN_BASE_URL || process.env.DASHSCOPE_BASE_URL || "https://coding.dashscope.aliyuncs.com/v1";
+const MIMO_BASE_URL = process.env.MIMO_BASE_URL || "https://token-plan-cn.xiaomimimo.com/v1";
+const DEFAULT_MODELS: Record<string, string> = {
+  deepseek: process.env.DEEPSEEK_MODEL || "deepseek-v4-pro",
+  qwen: process.env.QWEN_MODEL || "qwen3.6-plus",
+  mimo: process.env.MIMO_MODEL || "mimo-v2.5-pro",
+  openai: process.env.OPENAI_MODEL || "gpt-4o",
+  gemini: process.env.GEMINI_MODEL || "gemini-2.0-flash",
+  anthropic: process.env.ANTHROPIC_MODEL || "claude-sonnet-4-6",
+};
 
 function getOpenAI() {
   const key = process.env.OPENAI_API_KEY || getKey('OPENAI_API_KEY');
@@ -130,7 +143,7 @@ function getDeepSeek() {
   if (!deepseek && key) {
     deepseek = new OpenAI({
       apiKey: key,
-      baseURL: "https://api.deepseek.com"
+      baseURL: DEEPSEEK_BASE_URL,
     });
   }
   return deepseek;
@@ -142,11 +155,22 @@ function getQwen() {
     if (key) {
       qwen = new OpenAI({
         apiKey: key,
-        baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        baseURL: QWEN_BASE_URL,
       });
     }
   }
   return qwen;
+}
+
+function getMimo() {
+  const key = process.env.MIMO_API_KEY || getKey('MIMO_API_KEY');
+  if (!mimo && key) {
+    mimo = new OpenAI({
+      apiKey: key,
+      baseURL: MIMO_BASE_URL,
+    });
+  }
+  return mimo;
 }
 
 // Allow credentials from any origin (Tauri webview, localhost, etc.)
@@ -570,11 +594,12 @@ apiRouter.get("/llm/providers", (_req, res) => {
     !!(process.env[envKey] && process.env[envKey]!.length > 0) || !!stored[storeKey as keyof typeof stored];
   res.json({
     providers: {
-      deepseek: { available: envOrStore('DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY'), model: process.env.DEEPSEEK_MODEL || 'deepseek-chat' },
-      gemini: { available: envOrStore('GEMINI_API_KEY', 'GEMINI_API_KEY'), model: process.env.GEMINI_MODEL || 'gemini-2.0-flash' },
-      openai: { available: envOrStore('OPENAI_API_KEY', 'OPENAI_API_KEY'), model: process.env.OPENAI_MODEL || 'gpt-4o' },
-      anthropic: { available: envOrStore('ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY'), model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6' },
-      qwen: { available: envOrStore('QWEN_API_KEY', 'DASHSCOPE_API_KEY') || envOrStore('DASHSCOPE_API_KEY', 'DASHSCOPE_API_KEY'), model: process.env.QWEN_MODEL || 'qwen-plus' },
+      deepseek: { available: envOrStore('DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY'), model: DEFAULT_MODELS.deepseek },
+      gemini: { available: envOrStore('GEMINI_API_KEY', 'GEMINI_API_KEY'), model: DEFAULT_MODELS.gemini },
+      openai: { available: envOrStore('OPENAI_API_KEY', 'OPENAI_API_KEY'), model: DEFAULT_MODELS.openai },
+      anthropic: { available: envOrStore('ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY'), model: DEFAULT_MODELS.anthropic },
+      qwen: { available: envOrStore('QWEN_API_KEY', 'QWEN_API_KEY') || envOrStore('DASHSCOPE_API_KEY', 'DASHSCOPE_API_KEY'), model: DEFAULT_MODELS.qwen },
+      mimo: { available: envOrStore('MIMO_API_KEY', 'MIMO_API_KEY'), model: DEFAULT_MODELS.mimo },
     },
   });
 });
@@ -590,6 +615,7 @@ apiRouter.post("/llm/test", async (req, res) => {
       openai: process.env.OPENAI_API_KEY || stored.OPENAI_API_KEY,
       anthropic: process.env.ANTHROPIC_API_KEY || stored.ANTHROPIC_API_KEY,
       qwen: process.env.QWEN_API_KEY || process.env.DASHSCOPE_API_KEY || stored.QWEN_API_KEY || stored.DASHSCOPE_API_KEY,
+      mimo: process.env.MIMO_API_KEY || stored.MIMO_API_KEY,
     };
     const key = keyMap[provider];
     if (!key) {
@@ -669,14 +695,19 @@ apiRouter.post("/ai/chat", asyncHandler(async (req, res) => {
       } else if (provider === "anthropic") {
         const client = new Anthropic({ apiKey: userKey });
         const response = await client.messages.create({
-          model: model || "claude-sonnet-4-6", max_tokens: 1024,
+          model: model || DEFAULT_MODELS.anthropic, max_tokens: 1024,
           messages: messages || [{ role: "user", content: prompt }]
         });
         responseText = response.content[0].type === 'text' ? response.content[0].text : '';
       } else {
-        const client = new OpenAI({ apiKey: userKey, baseURL: provider === "deepseek" ? "https://api.deepseek.com" : provider === "qwen" ? "https://dashscope.aliyuncs.com/compatible-mode/v1" : undefined });
+        const providerBaseURL =
+          provider === "deepseek" ? DEEPSEEK_BASE_URL
+          : provider === "qwen" ? QWEN_BASE_URL
+          : provider === "mimo" ? MIMO_BASE_URL
+          : undefined;
+        const client = new OpenAI({ apiKey: userKey, baseURL: providerBaseURL });
         const response = await client.chat.completions.create({
-          model: model || (provider === "deepseek" ? "deepseek-chat" : provider === "qwen" ? "qwen-plus" : "gpt-4o"),
+          model: model || DEFAULT_MODELS[provider] || DEFAULT_MODELS.openai,
           messages: messages || [{ role: "user", content: prompt }]
         });
         responseText = response.choices[0].message.content || '';
@@ -704,12 +735,14 @@ apiRouter.post("/ai/chat", asyncHandler(async (req, res) => {
         const result = await runWithTools(
           normalizedMessages,
           toolRegistry,
-          { provider, model: model || 'gemini-2.0-flash', userId },
+          { provider, model: model || DEFAULT_MODELS[provider] || DEFAULT_MODELS.gemini, userId },
           undefined, 3,
           getDeepSeek, getGemini, getOpenAI, getAnthropic, getQwen,
           (chunk) => {
             res.write(`data: ${JSON.stringify({ chunk })}\n\n`);
           },
+          undefined,
+          getMimo,
         );
 
         responseText = result.text || '';
@@ -721,13 +754,16 @@ apiRouter.post("/ai/chat", asyncHandler(async (req, res) => {
         return res.end();
       }
 
-      const result = await runWithTools(
-        normalizedMessages,
-        toolRegistry,
-        { provider, model: model || 'gemini-2.0-flash', userId },
-        undefined, 3,
-        getDeepSeek, getGemini, getOpenAI, getAnthropic, getQwen,
-      );
+        const result = await runWithTools(
+          normalizedMessages,
+          toolRegistry,
+          { provider, model: model || DEFAULT_MODELS[provider] || DEFAULT_MODELS.gemini, userId },
+          undefined, 3,
+          getDeepSeek, getGemini, getOpenAI, getAnthropic, getQwen,
+          undefined,
+          undefined,
+          getMimo,
+        );
 
       responseText = result.text || '';
       const tokens = estimateTokens(

--- a/server/config/keys.ts
+++ b/server/config/keys.ts
@@ -11,6 +11,7 @@ interface KeyStore {
   GEMINI_API_KEY?: string;
   DEEPSEEK_API_KEY?: string;
   QWEN_API_KEY?: string;
+  MIMO_API_KEY?: string;
   MINIMAX_API_KEY?: string;
   E2B_API_KEY?: string;
 }
@@ -51,6 +52,7 @@ export function getAllKeyNames(): (keyof KeyStore)[] {
     'GEMINI_API_KEY',
     'DEEPSEEK_API_KEY',
     'QWEN_API_KEY',
+    'MIMO_API_KEY',
     'MINIMAX_API_KEY',
     'E2B_API_KEY',
   ];

--- a/server/llm/adapter.ts
+++ b/server/llm/adapter.ts
@@ -5,7 +5,7 @@ import { recordWorkflow, WorkflowStep } from '../skills/worklog';
 import { recordLatency } from '../monitor/latency_store';
 
 export interface LLMConfig {
-  provider: 'deepseek' | 'gemini' | 'openai' | 'anthropic' | 'qwen';
+  provider: 'deepseek' | 'gemini' | 'openai' | 'anthropic' | 'qwen' | 'mimo';
   model: string;
   maxTokens?: number;
   userId?: string;
@@ -38,6 +38,7 @@ export async function runWithTools(
   getQwen?: () => any,
   onStreamChunk?: StreamCallback,
   context?: ToolContext,
+  getMimo?: () => any,
 ): Promise<LLMResult> {
   const executionLog: ToolExecutionRecord[] = [];
   const usageRecords: LLMUsageRecord[] = [];
@@ -66,6 +67,7 @@ export async function runWithTools(
           getOpenAI || (() => null),
           getAnthropic || (() => null),
           getQwen || (() => null),
+          getMimo || (() => null),
         )
       : await makeLLMCall(
           conversationHistory,
@@ -76,6 +78,7 @@ export async function runWithTools(
           getOpenAI || (() => null),
           getAnthropic || (() => null),
           getQwen || (() => null),
+          getMimo || (() => null),
         );
     recordLatency('llm', Date.now() - llmStart);
 
@@ -197,6 +200,7 @@ export async function analyzeScreen(
   getOpenAI?: () => any,
   getAnthropic?: () => any,
   getQwen?: () => any,
+  getMimo?: () => any,
 ): Promise<string> {
   // Determine which vision model to use based on provider
   let provider = config.provider;
@@ -228,7 +232,7 @@ export async function analyzeScreen(
     messages, [],
     { provider: provider as any, model, maxTokens: 1000 },
     getDeepSeek || (() => null), getGemini || (() => null),
-    getOpenAI, getAnthropic, getQwen,
+    getOpenAI, getAnthropic, getQwen, getMimo,
   );
 
   return result.text || 'Vision analysis returned no text.';
@@ -243,7 +247,8 @@ export async function runWithVision(
   getOpenAI?: () => any,
   getAnthropic?: () => any,
   getQwen?: () => any,
+  getMimo?: () => any,
 ): Promise<string> {
-  const result = await makeLLMCall(messages, [], config, getDeepSeek || (() => null), getGemini || (() => null), getOpenAI, getAnthropic, getQwen);
+  const result = await makeLLMCall(messages, [], config, getDeepSeek || (() => null), getGemini || (() => null), getOpenAI, getAnthropic, getQwen, getMimo);
   return result.text || '';
 }

--- a/server/llm/providers.ts
+++ b/server/llm/providers.ts
@@ -359,18 +359,23 @@ export function parseAnthropicResponse(rawResponse: any): NormalizedLLMResponse 
 export async function makeLLMCall(
   messages: NormalizedMessage[],
   toolDeclarations: ToolDeclaration[],
-  config: { provider: 'deepseek' | 'gemini' | 'openai' | 'anthropic' | 'qwen'; model: string; maxTokens?: number; userId?: string },
+  config: { provider: 'deepseek' | 'gemini' | 'openai' | 'anthropic' | 'qwen' | 'mimo'; model: string; maxTokens?: number; userId?: string },
   getDeepSeek: () => any,
   getGemini: () => any,
   getOpenAI?: () => any,
   getAnthropic?: () => any,
   getQwen?: () => any,
+  getMimo?: () => any,
 ): Promise<NormalizedLLMResponse> {
-  if (config.provider === 'deepseek' || config.provider === 'qwen') {
-    const client = config.provider === 'deepseek' ? getDeepSeek() : getQwen?.();
+  if (config.provider === 'deepseek' || config.provider === 'qwen' || config.provider === 'mimo') {
+    const client = config.provider === 'deepseek'
+      ? getDeepSeek()
+      : config.provider === 'qwen'
+        ? getQwen?.()
+        : getMimo?.();
     if (!client) throw new Error(`${config.provider} not configured (API key missing)`);
 
-    const formatFn = config.provider === 'qwen' ? formatQwenRequest : formatDeepSeekRequest;
+    const formatFn = config.provider === 'qwen' || config.provider === 'mimo' ? formatQwenRequest : formatDeepSeekRequest;
     const params = formatFn({
       model: config.model,
       messages,
@@ -440,22 +445,24 @@ export type StreamCallback = (chunk: string) => void;
 export async function makeLLMCallStreaming(
   messages: NormalizedMessage[],
   toolDeclarations: ToolDeclaration[],
-  config: { provider: 'deepseek' | 'gemini' | 'openai' | 'anthropic' | 'qwen'; model: string; maxTokens?: number; userId?: string; signal?: AbortSignal },
+  config: { provider: 'deepseek' | 'gemini' | 'openai' | 'anthropic' | 'qwen' | 'mimo'; model: string; maxTokens?: number; userId?: string; signal?: AbortSignal },
   onChunk: StreamCallback,
   getDeepSeek: () => any,
   getGemini: () => any,
   getOpenAI?: () => any,
   getAnthropic?: () => any,
   getQwen?: () => any,
+  getMimo?: () => any,
 ): Promise<NormalizedLLMResponse> {
   // ── DeepSeek / OpenAI / Qwen (OpenAI-compatible streaming) ──
-  if (config.provider === 'deepseek' || config.provider === 'openai' || config.provider === 'qwen') {
+  if (config.provider === 'deepseek' || config.provider === 'openai' || config.provider === 'qwen' || config.provider === 'mimo') {
     const client = config.provider === 'deepseek' ? getDeepSeek()
       : config.provider === 'openai' ? getOpenAI?.()
-      : getQwen?.();
+      : config.provider === 'qwen' ? getQwen?.()
+      : getMimo?.();
     if (!client) throw new Error(`${config.provider} not configured`);
 
-    const formatFn = config.provider === 'qwen' ? formatQwenRequest : formatDeepSeekRequest;
+    const formatFn = config.provider === 'qwen' || config.provider === 'mimo' ? formatQwenRequest : formatDeepSeekRequest;
     const params: any = formatFn({
       model: config.model,
       messages,

--- a/server/routes/system_routes.ts
+++ b/server/routes/system_routes.ts
@@ -8,6 +8,15 @@ import { scheduler } from "../scheduler";
 import { loadKeys, saveKeys, getKey, getAllKeyNames } from "../config/keys";
 import { getLatencyStats } from "../monitor/latency_store";
 
+const DEFAULT_MODELS: Record<string, string> = {
+  deepseek: process.env.DEEPSEEK_MODEL || 'deepseek-v4-pro',
+  gemini: process.env.GEMINI_MODEL || 'gemini-2.0-flash',
+  openai: process.env.OPENAI_MODEL || 'gpt-4o',
+  anthropic: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6',
+  qwen: process.env.QWEN_MODEL || 'qwen3.6-plus',
+  mimo: process.env.MIMO_MODEL || 'mimo-v2.5-pro',
+};
+
 export function mountSystemRoutes(router: Router, jwtSecret: string) {
   // Health Check
   router.get("/health", (req, res) => {
@@ -107,11 +116,12 @@ export function mountSystemRoutes(router: Router, jwtSecret: string) {
       !!(process.env[envKey] && process.env[envKey]!.length > 0) || !!stored[storeKey as keyof typeof stored];
     res.json({
       providers: {
-        deepseek: { available: envOrStore('DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY'), model: process.env.DEEPSEEK_MODEL || 'deepseek-chat' },
-        gemini: { available: envOrStore('GEMINI_API_KEY', 'GEMINI_API_KEY'), model: process.env.GEMINI_MODEL || 'gemini-2.0-flash' },
-        openai: { available: envOrStore('OPENAI_API_KEY', 'OPENAI_API_KEY'), model: process.env.OPENAI_MODEL || 'gpt-4o' },
-        anthropic: { available: envOrStore('ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY'), model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6' },
-        qwen: { available: envOrStore('QWEN_API_KEY', 'DASHSCOPE_API_KEY') || envOrStore('DASHSCOPE_API_KEY', 'DASHSCOPE_API_KEY'), model: process.env.QWEN_MODEL || 'qwen-plus' },
+        deepseek: { available: envOrStore('DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY'), model: DEFAULT_MODELS.deepseek },
+        gemini: { available: envOrStore('GEMINI_API_KEY', 'GEMINI_API_KEY'), model: DEFAULT_MODELS.gemini },
+        openai: { available: envOrStore('OPENAI_API_KEY', 'OPENAI_API_KEY'), model: DEFAULT_MODELS.openai },
+        anthropic: { available: envOrStore('ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY'), model: DEFAULT_MODELS.anthropic },
+        qwen: { available: envOrStore('QWEN_API_KEY', 'QWEN_API_KEY') || envOrStore('DASHSCOPE_API_KEY', 'DASHSCOPE_API_KEY'), model: DEFAULT_MODELS.qwen },
+        mimo: { available: envOrStore('MIMO_API_KEY', 'MIMO_API_KEY'), model: DEFAULT_MODELS.mimo },
       },
     });
   });
@@ -127,6 +137,7 @@ export function mountSystemRoutes(router: Router, jwtSecret: string) {
         openai: apiKey || process.env.OPENAI_API_KEY || stored.OPENAI_API_KEY,
         anthropic: apiKey || process.env.ANTHROPIC_API_KEY || stored.ANTHROPIC_API_KEY,
         qwen: apiKey || process.env.QWEN_API_KEY || process.env.DASHSCOPE_API_KEY || stored.QWEN_API_KEY || stored.DASHSCOPE_API_KEY,
+        mimo: apiKey || process.env.MIMO_API_KEY || stored.MIMO_API_KEY,
       };
       const key = keyMap[provider];
       if (!key) {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -184,6 +184,7 @@ export function Settings({
                       className="w-full bg-white/5 border border-white/10 rounded-2xl px-4 py-3 text-sm font-bold appearance-none cursor-pointer focus:border-celestial-saturn/50 outline-none">
                       <option value="deepseek">DeepSeek</option>
                       <option value="qwen">Qwen (DashScope)</option>
+                      <option value="mimo">Xiaomi Mimo</option>
                       <option value="gemini">Google Gemini</option>
                       <option value="openai">OpenAI</option>
                       <option value="anthropic">Anthropic Claude</option>
@@ -721,7 +722,7 @@ function ApiMatrixPage({ t, providerStatus }: { t: any; providerStatus: Record<s
                 icon={<BrainCircuit size={18} className="text-blue-400" />}
                 label="DeepSeek"
                 providerId="deepseek"
-                models={['deepseek-chat', 'deepseek-reasoner']}
+                models={['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-reasoner']}
                 placeholder="sk-..."
                 serverKey="DEEPSEEK_API_KEY"
                 t={t}
@@ -730,9 +731,18 @@ function ApiMatrixPage({ t, providerStatus }: { t: any; providerStatus: Record<s
                 icon={<Zap size={18} className="text-violet-400" />}
                 label="Qwen / DashScope (Alibaba Cloud)"
                 providerId="qwen"
-                models={['qwen-plus', 'qwen-max', 'qwen-turbo']}
+                models={['qwen3.6-plus', 'qwen-max', 'qwen-turbo']}
                 placeholder="sk-..."
                 serverKey="DASHSCOPE_API_KEY"
+                t={t}
+              />
+              <LLMProviderRow
+                icon={<Zap size={18} className="text-orange-400" />}
+                label="Xiaomi Mimo"
+                providerId="mimo"
+                models={['mimo-v2.5-pro']}
+                placeholder="tp-..."
+                serverKey="MIMO_API_KEY"
                 t={t}
               />
               <LLMProviderRow

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -92,7 +92,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [aiConfig, setAiConfig] = useState<AIConfig>(() => {
     const saved = localStorage.getItem('lumi_ai_config');
-    return saved ? JSON.parse(saved) : { provider: 'deepseek', model: 'deepseek-chat', apiKey: '' };
+    return saved ? JSON.parse(saved) : { provider: 'deepseek', model: 'deepseek-v4-pro', apiKey: '' };
   });
   // Voice state
   const [selectedVoiceId, setSelectedVoiceIdState] = useState<string | undefined>(() => {
@@ -133,7 +133,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
           try { return JSON.parse(localStorage.getItem('lumi_llm_models') || '{}'); } catch { return {}; }
         })();
         const defaults: Record<string, string> = {
-          qwen: 'qwen-plus', deepseek: 'deepseek-chat', openai: 'gpt-4o',
+          qwen: 'qwen3.6-plus', deepseek: 'deepseek-v4-pro', mimo: 'mimo-v2.5-pro', openai: 'gpt-4o',
           gemini: 'gemini-2.0-flash', anthropic: 'claude-sonnet-4-6',
         };
         resolved.model = savedModels[newConfig.provider] || defaults[newConfig.provider] || '';
@@ -146,6 +146,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         const KEY_MAP: Record<string, string> = {
           qwen: 'DASHSCOPE_API_KEY',
           deepseek: 'DEEPSEEK_API_KEY',
+          mimo: 'MIMO_API_KEY',
           openai: 'OPENAI_API_KEY',
           gemini: 'GEMINI_API_KEY',
           anthropic: 'ANTHROPIC_API_KEY',


### PR DESCRIPTION
## Summary
- add Xiaomi Mimo provider recognition to the LLM configuration flow
- add MIMO_API_KEY, MIMO_MODEL, and MIMO_BASE_URL configuration support
- make DeepSeek and Qwen base URLs configurable
- update settings UI to expose Xiaomi Mimo as a selectable provider
- align default DeepSeek and Qwen model values with current configuration

## Notes
- this PR adds provider/configuration support only
- DeepSeek and Qwen compatibility endpoints were validated successfully in local WSL testing
- Xiaomi Mimo endpoint integration is wired as an OpenAI-compatible provider, but upstream endpoint testing currently returned 502 Bad Gateway`n- because of that, this PR should be reviewed as configuration/readiness support, not as confirmed production-ready Mimo availability